### PR TITLE
Feature/57 Configure Cursor workspace

### DIFF
--- a/.cursor/rules/documentation.mdc
+++ b/.cursor/rules/documentation.mdc
@@ -1,0 +1,33 @@
+---
+description: Markdown documentation conventions for docs/
+globs: docs/**/*.md
+alwaysApply: false
+---
+
+# Documentation Conventions
+
+Follow `docs/project-brief.md` writing principles.
+
+## Structure
+
+- One primary purpose per document; cross-reference instead of duplicating
+- Use clear headings, tables, and checklists where helpful
+- Include a Document Status section for core docs when updating them
+
+## Content rules
+
+- Professional facts belong in `docs/professional-profile.md` only
+- Narrative and tone belong in `docs/personal-brand.md`
+- Website requirements belong in `docs/website-specification.md`
+- Do not embed employment history in workflow or AI guide documents
+
+## Links
+
+- Use relative paths between docs (e.g., `./professional-profile.md`)
+- Verify internal links resolve after creating or renaming files
+- Reference templates in `docs/templates/` for audits, plans, and issues
+
+## Templates
+
+- Use placeholders (`[PLACEHOLDER]`) — never fabricated audit findings or professional claims
+- Remove instruction blocks when converting a template to a completed document

--- a/.cursor/rules/git-workflow.mdc
+++ b/.cursor/rules/git-workflow.mdc
@@ -1,0 +1,41 @@
+---
+description: Branch, commit, and Pull Request conventions
+alwaysApply: true
+---
+
+# Git Workflow
+
+Follow `docs/development-workflow.md`.
+
+## Branch naming
+
+| Type | Pattern | Example |
+|------|---------|---------|
+| Feature | `feature/<issue-number>-<short-slug>` | `feature/57-configure-cursor-workspace` |
+| Fix | `fix/<issue-number>-<short-slug>` | `fix/62-contact-form-validation` |
+
+Use lowercase slugs with hyphens. Branch from `develop` unless the issue specifies otherwise.
+
+## Commit messages
+
+```
+#<issue-number> <concise description>
+```
+
+Example: `#57 Configure Cursor workspace`
+
+- Reference the issue number in every commit
+- One logical change per commit when practical
+- Do not commit secrets, credentials, or `.env` files
+
+## Pull Requests
+
+Every PR must:
+
+1. Reference the GitHub Issue (e.g., "Closes #57")
+2. Reference the parent issue when applicable (e.g., "Parent: #55 — Project Discovery")
+3. Include a summary and validation performed
+4. Confirm scope boundaries were respected
+5. List changed files when the change set is non-trivial
+
+Do not merge without human review and approval.

--- a/.cursor/rules/issue-workflow.mdc
+++ b/.cursor/rules/issue-workflow.mdc
@@ -1,0 +1,40 @@
+---
+description: Issue workflow, planning vs implementation, and approval gate
+alwaysApply: true
+---
+
+# Issue Workflow
+
+Follow `docs/development-workflow.md` and `docs/ai-collaboration-guide.md`.
+
+## Required sequence
+
+1. Read the current GitHub Issue
+2. Read the parent issue
+3. Read all referenced documentation
+4. Inspect the repository
+5. Identify affected files, dependencies, risks, and assumptions
+6. Produce an implementation plan using `docs/templates/implementation-plan-template.md`
+7. **Wait for approval** — do not edit files
+8. Implement only the approved scope
+9. Run relevant validation
+10. Produce a delivery report
+11. Prepare a focused commit (when requested)
+12. Open or prepare a Pull Request referencing the issue
+
+## Approval gate
+
+- Default: plan first; no file changes until the plan is approved
+- "Read-only planning mode" = steps 1–6 only
+- Direct implementation is allowed only when:
+  - The issue explicitly permits it, or
+  - The user approves the plan in the same conversation, or
+  - The scope is narrow, fully specified, and documentation-only
+
+When in doubt, plan first and wait for approval.
+
+## Issue drafting
+
+When proposing new issues, follow `docs/templates/github-issue-template.md`.
+
+Record significant workflow or architecture decisions in `docs/decision-log.md`.

--- a/.cursor/rules/nextjs-code.mdc
+++ b/.cursor/rules/nextjs-code.mdc
@@ -1,0 +1,33 @@
+---
+description: Next.js and React coding conventions for src/
+globs: src/**/*.{ts,tsx,scss}
+alwaysApply: false
+---
+
+# Next.js Code Conventions
+
+Follow `docs/project-brief.md` technical principles. Match existing patterns before introducing new ones.
+
+## Stack
+
+- Next.js App Router (`src/app/`)
+- TypeScript, React functional components
+- SCSS modules colocated with components (`*.module.scss`)
+- Path aliases: `@/app/`, `@components/`, `@img/`
+
+## Implementation rules
+
+- Prefer the smallest correct diff
+- Reuse existing components (`button`, `spacer`, `input`, etc.)
+- Preserve current visual identity unless the issue specifies redesign
+- Preserve accessibility, responsiveness, and SEO unless the issue targets changes
+- Avoid unnecessary dependencies
+- Do not refactor unrelated code
+
+## Content in components
+
+Website copy must align with `docs/professional-profile.md` and `docs/personal-brand.md`. See `docs/website-specification.md` for required corrections.
+
+## Validation
+
+Run `npm run lint` and `npm run build` before delivery when code changes are in scope.

--- a/.cursor/rules/professional-content.mdc
+++ b/.cursor/rules/professional-content.mdc
@@ -1,0 +1,34 @@
+---
+description: Professional content rules for docs and website copy
+globs: docs/**/*.md,src/**/*.tsx
+alwaysApply: false
+---
+
+# Professional Content
+
+Follow `docs/professional-profile.md` for facts and `docs/personal-brand.md` for narrative and tone.
+
+## Facts
+
+- Use `docs/professional-profile.md` as the factual source
+- Do not invent employers, dates, titles, metrics, tools, certifications, or client details
+- Retain qualifiers such as "approximately" where the profile uses them
+- Separate responsibilities from verified outcomes
+
+## Tone and terminology
+
+- Clear, formal, natural English; short, direct sentences
+- Primary positioning: Senior Front-End Designer and Product Designer
+- Use verified company and role names from the profile
+- Avoid exaggerated superlatives and unsupported claims
+- Keep recruiter-facing content concise and easy to scan
+
+## Do not
+
+- Copy stale website content when it conflicts with the profile
+- Add regulatory, financial, or penalty claims unless verified in the resume
+- Use "volunteer" framing unless explicitly verified
+- Add proficiency percentages or skill bars without evidence
+- Position AI as the centre of the professional identity
+
+When website content conflicts with the profile, follow the profile and flag the discrepancy.

--- a/.cursor/rules/project-context.mdc
+++ b/.cursor/rules/project-context.mdc
@@ -1,0 +1,40 @@
+---
+description: Project context, documentation index, and source-of-truth hierarchy
+alwaysApply: true
+---
+
+# Personal Website — Project Context
+
+Read the current GitHub Issue, parent issue, and relevant docs in `docs/` before any work.
+
+## Documentation index
+
+| Need | Document |
+|------|----------|
+| Verified professional facts | `docs/professional-profile.md` |
+| Narrative and tone | `docs/personal-brand.md` |
+| Project vision and principles | `docs/project-brief.md` |
+| Website requirements | `docs/website-specification.md` |
+| Issue lifecycle | `docs/development-workflow.md` |
+| AI collaboration rules | `docs/ai-collaboration-guide.md` |
+| Project decisions | `docs/decision-log.md` |
+
+## Source-of-truth hierarchy
+
+When information conflicts, use this order:
+
+1. Latest approved resume
+2. `docs/professional-profile.md`
+3. `docs/project-brief.md`
+4. `docs/personal-brand.md`
+5. `docs/website-specification.md`
+6. `docs/development-workflow.md`
+7. `docs/ai-collaboration-guide.md`
+8. Current GitHub Issue
+9. Parent Issue
+
+Professional facts always defer to the resume and `docs/professional-profile.md`.
+
+Never treat live website content (`src/app/**`) as authoritative when it conflicts with the profile. Flag discrepancies and follow the profile.
+
+Never invent, exaggerate, or add unsupported professional information.

--- a/.cursor/rules/scope-control.mdc
+++ b/.cursor/rules/scope-control.mdc
@@ -1,0 +1,30 @@
+---
+description: Scope discipline and out-of-scope handling
+alwaysApply: true
+---
+
+# Scope Control
+
+Follow `docs/development-workflow.md` and `docs/ai-collaboration-guide.md`.
+
+## Rules
+
+- Implement only what the current issue deliverables specify
+- Do not perform unrelated refactoring, redesign, or drive-by fixes
+- Do not bundle unrelated changes "while you're here"
+- Do not delete files or restructure the repository unless the issue requires it
+- Stop and ask for approval when requirements conflict or scope is ambiguous
+
+## Out-of-scope findings
+
+When additional work is discovered:
+
+1. Document the finding briefly
+2. Propose a future issue using `docs/templates/github-issue-template.md`
+3. Do **not** implement it automatically
+4. List deferred items in the delivery report
+
+## Content changes
+
+- Do not rewrite website content unless the issue explicitly includes it
+- Do not modify `docs/professional-profile.md` facts without resume verification and approval

--- a/.cursor/rules/validation-and-delivery.mdc
+++ b/.cursor/rules/validation-and-delivery.mdc
@@ -1,0 +1,33 @@
+---
+description: Validation checks and delivery report requirements
+alwaysApply: true
+---
+
+# Validation and Delivery
+
+Follow `docs/development-workflow.md` for the full validation table and delivery report format.
+
+## Validation by change type
+
+| Change type | Required checks |
+|-------------|-------------------|
+| Code (`src/**`) | `npm run lint`, `npm run build` |
+| Documentation (`docs/**`) | Markdown formatting, internal links resolve |
+| Professional content | Compare against `docs/professional-profile.md` |
+| All issues | Confirm no out-of-scope files changed |
+
+For code changes, note responsive, accessibility, SEO, and performance impact when relevant. Fix only if in scope.
+
+## Delivery report
+
+After implementation, provide:
+
+- Issue reference and branch name
+- Summary of changes
+- Files created, modified, or deleted
+- Validation results
+- Important decisions, assumptions, and risks
+- Out-of-scope items deferred to future issues
+- Recommended next issue (when applicable)
+
+Do not commit or push unless explicitly requested.

--- a/.cursorignore
+++ b/.cursorignore
@@ -1,0 +1,20 @@
+﻿# Dependencies
+node_modules/
+
+# Next.js build output
+.next/
+out/
+build/
+
+# Debug and local env
+npm-debug.log*
+.env*.local
+
+# Vercel
+.vercel
+
+# TypeScript build info
+*.tsbuildinfo
+
+# OS
+.DS_Store

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,45 @@
+# AGENTS.md — Personal Website Repository
+
+This repository is Maikel Salles's personal website and professional brand source of truth. AI assistants should follow the rules in `.cursor/rules/` and the documentation in `docs/`.
+
+## Start here
+
+1. Read the current GitHub Issue and parent issue
+2. Read relevant docs from the index below
+3. Follow the issue workflow in `.cursor/rules/issue-workflow.mdc`
+4. Wait for approval before implementing unless explicitly allowed
+
+## Documentation index
+
+| Document | Use when |
+|----------|----------|
+| [docs/professional-profile.md](docs/professional-profile.md) | Verifying professional facts |
+| [docs/personal-brand.md](docs/personal-brand.md) | Narrative, tone, terminology |
+| [docs/project-brief.md](docs/project-brief.md) | Project vision and principles |
+| [docs/website-specification.md](docs/website-specification.md) | Website content requirements |
+| [docs/development-workflow.md](docs/development-workflow.md) | Issue lifecycle, git, validation |
+| [docs/ai-collaboration-guide.md](docs/ai-collaboration-guide.md) | AI approval boundaries |
+| [docs/decision-log.md](docs/decision-log.md) | Project decisions |
+
+## Templates
+
+| Template | Use when |
+|----------|----------|
+| [docs/templates/implementation-plan-template.md](docs/templates/implementation-plan-template.md) | Preparing implementation plans |
+| [docs/templates/github-issue-template.md](docs/templates/github-issue-template.md) | Drafting new issues |
+| [docs/templates/case-study-template.md](docs/templates/case-study-template.md) | Writing portfolio case studies |
+
+## Cursor rules
+
+Rules in `.cursor/rules/` enforce workflow, scope, validation, and coding conventions. They reference `docs/` — do not duplicate long-form content in rules.
+
+## Hard rules
+
+- Never invent professional information
+- Never treat live website content as authoritative over `docs/professional-profile.md`
+- Implement only the approved issue scope
+- Plan first and wait for approval by default
+
+## Tech stack
+
+Next.js App Router, TypeScript, React, SCSS modules. Source in `src/app/`.

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -121,6 +121,26 @@ Do not duplicate verified professional facts from [professional-profile.md](./pr
 
 ---
 
+### DEC-006 — Cursor workspace configuration
+
+| Field | Value |
+|-------|-------|
+| Date | 2026-07-25 |
+| Status | Accepted |
+| Related | Issue #57 — Configure Cursor Workspace |
+
+**Context:** Issue #56 created repository documentation, but Cursor had no project-level rules to enforce workflow, scope, and factual accuracy automatically.
+
+**Decision:** Configure `.cursor/rules/` with focused rule files that reference `docs/` instead of duplicating content. Add `AGENTS.md` as the repository entry point and `.cursorignore` for build artifacts.
+
+**Alternatives considered:** Single monolithic rule file; legacy `.cursorrules`; embedding full workflow in rules.
+
+**Reason:** Focused rules remain maintainable; documentation stays the canonical source; agents get a clear entry point without repeated prompts.
+
+**Impact:** Eight rules cover context, workflow, scope, validation, git, professional content, documentation, and Next.js code. Website and production code are unchanged.
+
+---
+
 ## Document Status
 
 | Field | Value |


### PR DESCRIPTION
## Summary
- Add focused Cursor rules in `.cursor/rules/` that reference repository documentation instead of duplicating it.
- Add `AGENTS.md` as the repository entry point for AI assistants.
- Add `.cursorignore` to exclude build artifacts from indexing.
- Record DEC-006 in `docs/decision-log.md`.

## Related issues
- Closes #57
- Parent: #55 — Project Discovery

## Test plan
- [x] Verify `.cursor/rules/` contains 8 rule files with correct frontmatter
- [x] Confirm rules reference `docs/` and do not duplicate professional facts
- [x] Confirm no website or production code was modified
- [x] Review `AGENTS.md` doc index and links
- [x] Manually test a short issue prompt triggers planning workflow