### PR TITLE
Improve Semantic HTML Structure

### DIFF
--- a/src/app/_mixins.scss
+++ b/src/app/_mixins.scss
@@ -29,14 +29,6 @@
     justify-content: flex-start;
     align-items: stretch;
     gap: 1rem;
-    &:before {
-        content: " ";
-        background-color: var(--primary-regular);
-        width: 6px;
-        display: block;
-        margin: .2em 0;
-        border-radius: 3px;
-      }
 }
 
 .filledBox {

--- a/src/app/globals.scss
+++ b/src/app/globals.scss
@@ -153,11 +153,9 @@ h1 {
   margin: 0;
   font-size: var(--font-size-1);
   text-align: center;
-  text-transform: uppercase;
 }
 
 h2 {
-  text-transform: uppercase;
   padding: 0;
   margin: 0;
   font-size: var(--font-size-2);

--- a/src/app/portfolio/design-system-engineer/page.tsx
+++ b/src/app/portfolio/design-system-engineer/page.tsx
@@ -21,50 +21,73 @@ export const metadata: Metadata = {
 export default function Resume() {
     return (
         <article className={`${globals.wrapper} ${globals.sectionPadding} ${styles.resumeContainer}`}>
-            <div className={styles.titleContainer}>
-                <span className={styles.breadcrumbs}><a href="/portfolio" title="Back to Portfolio" rel="nofollow noindex">Portfolio</a></span>
+            <header className={styles.titleContainer}>
+                <p className={styles.eyebrow}>Design System Strategist</p>
                 <h1>Design System</h1>
-            </div>
-            <section id="personal-website" className={styles.caseContainer}>
-                <div>
-                    <p>
-                        I transitioned from Product Designer to fully focus on integrating the design system into the company's daily operations. My goal was to institutionalize its use and collaborate with the software engineering team to optimize performance and utilization. By developing processes and fostering cross-departmental alignment, we aimed to ensure the design system's seamless integration and maximize its benefits across the organization.
-                    </p>
-                    <p>
-                        Recognizing the need for leadership to streamline internal processes and reduce excessive revisions in prototype development, so I volunteered to lead the design team. At the time, with only four designers reporting directly to product owners and minimal communication among them, I saw the opportunity to establish clearer channels of communication, standardize processes, and enhance the efficiency and quality of our design outputs.
-                    </p>
-                </div>
-                <div>
-                    <h3>Problem solving approach for legacy design</h3>
-                    <p>
-                        I embraced the task of building a design system to unify multiple legacy projects with old and inconsistent designs. This involved auditing existing designs, defining clear design principles, creating a comprehensive component library, establishing design tokens, documenting guidelines and best practices, implementing gradually across projects, and monitoring ongoing usage.
-                    </p>
-                    <p>
-                        Through this systematic approach, I ensured consistency, efficiency, and scalability, harmonizing disparate designs and enhancing the overall user experience across all projects.
-                    </p>
-                </div>
+                <p>Fleet Management and Payments</p>
+                <dl className={styles.caseDetails}>
+                    <div>
+                        <dt>Role</dt>
+                        <dd>Design System Strategist</dd>
+                    </div>
+                    <div>
+                        <dt>Company</dt>
+                        <dd>DBC Consulting — Ticket Log / Edenred</dd>
+                    </div>
+                    <div>
+                        <dt>Dates</dt>
+                        <dd>2022–2024</dd>
+                    </div>
+                </dl>
+            </header>
+            <section className={styles.caseContainer} aria-labelledby="design-system-overview">
+                <h2 id="design-system-overview">Overview</h2>
+                <p>
+                    I transitioned from Product Designer to fully focus on integrating the design system into the company's daily operations. My goal was to institutionalize its use and collaborate with the software engineering team to optimize performance and utilization. By developing processes and fostering cross-departmental alignment, we aimed to ensure the design system's seamless integration and maximize its benefits across the organization.
+                </p>
+                <p>
+                    Recognizing the need for leadership to streamline internal processes and reduce excessive revisions in prototype development, so I volunteered to lead the design team. At the time, with only four designers reporting directly to product owners and minimal communication among them, I saw the opportunity to establish clearer channels of communication, standardize processes, and enhance the efficiency and quality of our design outputs.
+                </p>
+            </section>
+            <section className={styles.caseContainer} aria-labelledby="legacy-design">
+                <h2 id="legacy-design">Problem solving approach for legacy design</h2>
+                <p>
+                    I embraced the task of building a design system to unify multiple legacy projects with old and inconsistent designs. This involved auditing existing designs, defining clear design principles, creating a comprehensive component library, establishing design tokens, documenting guidelines and best practices, implementing gradually across projects, and monitoring ongoing usage.
+                </p>
+                <p>
+                    Through this systematic approach, I ensured consistency, efficiency, and scalability, harmonizing disparate designs and enhancing the overall user experience across all projects.
+                </p>
                 <div className={styles.advise}>
                     <span className={`${icons.info} ${icons.icon}`}></span>
                     The details of this project are confidential, however, I can provide a brief overview.
                 </div>
-                <picture>
-                    <source srcSet={img1.src} />
-                    <Image src={img1} alt="A print screen from Azure DevOps showing a kanban board with tasks." />
-                </picture>
-                <div>
-                    <h3>Team work and collaboration</h3>
-                    <p>I organized workshops to empower the IT and design teams to actively maintain and update the design system, providing hands-on training and guidance. This ensured that both teams were equipped with the skills and resources needed to sustain the system's relevance and effectiveness over time.</p>
-                </div>
-                <div>
-                    <h3>Library of components</h3>
-                    <p>I developed the components in an Angular 17 library and documented them using Storybook 8. Additionally, I updated a playground for developers to conduct testing and development with the legacy and new components to measure the impact and compatibility on development within legacy platforms. All these efforts were guided by best development practices and standards, with a continued commitment to accessibility. This approach ensured not only the consistency and efficiency of the system but also its user-friendliness and accessibility for all users.</p>
-                </div>
-                <picture>
-                    <source srcSet={img2.src} />
-                    <Image src={img2} alt="The image is half with Storybook showcasing some components and the other half is the VsCode showing code." />
-                </picture>
+                <figure>
+                    <picture>
+                        <source srcSet={img1.src} />
+                        <Image src={img1} alt="A print screen from Azure DevOps showing a kanban board with tasks." />
+                    </picture>
+                </figure>
             </section>
-            <Button href="/portfolio" icon="long-arrow-alt-left" label="Back to Portfolio"/>
+            <section className={styles.caseContainer} aria-labelledby="team-collaboration">
+                <h2 id="team-collaboration">Team work and collaboration</h2>
+                <p>I organized workshops to empower the IT and design teams to actively maintain and update the design system, providing hands-on training and guidance. This ensured that both teams were equipped with the skills and resources needed to sustain the system's relevance and effectiveness over time.</p>
+            </section>
+            <section className={styles.caseContainer} aria-labelledby="component-library">
+                <h2 id="component-library">Library of components</h2>
+                <p>I developed the components in an Angular 17 library and documented them using Storybook 8. Additionally, I updated a playground for developers to conduct testing and development with the legacy and new components to measure the impact and compatibility on development within legacy platforms. All these efforts were guided by best development practices and standards, with a continued commitment to accessibility. This approach ensured not only the consistency and efficiency of the system but also its user-friendliness and accessibility for all users.</p>
+                <figure>
+                    <picture>
+                        <source srcSet={img2.src} />
+                        <Image src={img2} alt="The image is half with Storybook showcasing some components and the other half is the VsCode showing code." />
+                    </picture>
+                </figure>
+            </section>
+            <footer className={styles.caseFooter}>
+                <nav aria-label="Case study navigation">
+                    <Button href="/portfolio" icon="long-arrow-alt-left" label="Back to Portfolio"/>
+                    <Button href="/portfolio/head-of-product-design" label="Next case study"/>
+                </nav>
+            </footer>
         </article>
     )
 }

--- a/src/app/portfolio/head-of-product-design/page.tsx
+++ b/src/app/portfolio/head-of-product-design/page.tsx
@@ -12,32 +12,49 @@ export const metadata: Metadata = {
 export default function Resume() {
     return (
         <article className={`${globals.wrapper} ${globals.sectionPadding} ${styles.resumeContainer}`}>
-            <div className={styles.titleContainer}>
-                <span className={styles.breadcrumbs}><a href="/portfolio" title="Back to Portfolio" rel="nofollow noindex">Portfolio</a></span>
+            <header className={styles.titleContainer}>
+                <p className={styles.eyebrow}>At a Glance</p>
                 <h1>Designing the Design Organization</h1>
-            </div>
-            <section id="head-of-product-design" className={`${styles.caseContainer} ${styles.longFormCaseStudy}`}>
-                <h2>Building a Product Design Operating Model</h2>
-                <h2>At a Glance</h2>
-                <p><strong>Role:</strong> Head of Product Design</p>
-                <p><strong>Context:</strong> Enterprise fleet-management and payment products</p>
-                <p><strong>Focus:</strong> Service Design, Design Operations, accessibility, team development, and Design Systems</p>
-                <p><strong>Team growth:</strong> From 3 Product Designers to 10 Product Designers and 2 UX Writers</p>
-                <p><strong>Key outcomes:</strong> A new cross-functional design operating model, clearer ownership across teams, stronger accessibility and research practices, a shared Design System foundation, and an estimated 30% reduction in design and development time.</p>
-
-                <h2>Overview</h2>
+                <p>Building a Product Design Operating Model</p>
+                <dl className={styles.caseDetails}>
+                    <div>
+                        <dt>Role:</dt>
+                        <dd>Head of Product Design</dd>
+                    </div>
+                    <div>
+                        <dt>Context:</dt>
+                        <dd>Enterprise fleet-management and payment products</dd>
+                    </div>
+                    <div>
+                        <dt>Focus:</dt>
+                        <dd>Service Design, Design Operations, accessibility, team development, and Design Systems</dd>
+                    </div>
+                    <div>
+                        <dt>Team growth:</dt>
+                        <dd>From 3 Product Designers to 10 Product Designers and 2 UX Writers</dd>
+                    </div>
+                    <div>
+                        <dt>Key outcomes:</dt>
+                        <dd>A new cross-functional design operating model, clearer ownership across teams, stronger accessibility and research practices, a shared Design System foundation, and an estimated 30% reduction in design and development time.</dd>
+                    </div>
+                </dl>
+            </header>
+            <section className={`${styles.caseContainer} ${styles.longFormCaseStudy}`} aria-labelledby="overview">
+                <h2 id="overview">Overview</h2>
                 <p>Ticket Log by Edenred operated several fleet-management and payment products built by different teams, using different technologies and different ways of working.</p>
                 <p>Design was usually involved late in the process, after Product and Engineering had already defined the problem and selected a solution. Designers were expected to create interfaces without enough context, research, or influence over the final product.</p>
                 <p>I was promoted to Head of Product Design to create a formal design function and establish a better way for Design, Product, Engineering, Business, Support, Legal, Compliance, clients, and users to work together.</p>
                 <p>This case was not about redesigning one feature. It was about redesigning the service used to identify, design, build, validate, and improve every product experience.</p>
-
-                <h2>My Role</h2>
+            </section>
+            <section className={`${styles.caseContainer} ${styles.longFormCaseStudy}`} aria-labelledby="my-role">
+                <h2 id="my-role">My Role</h2>
                 <p>As Head of Product Design, I led the definition and adoption of a new Product Design operating model.</p>
                 <p>The goal was to give designers clearer guidance and a stronger role in understanding user needs, defining problems, shaping solutions, validating implementation, and measuring results.</p>
                 <p>I remained directly involved in research, workshops, workflow design, documentation, accessibility, prototyping, testing, and delivery. I also supported hiring, onboarding, mentoring, workload planning, team development, and the early stages of the Design System.</p>
                 <p>Beyond creating a process, I helped change how the company understood Design and established a longer-term vision for more consistent, accessible, scalable, and future-ready product delivery.</p>
-
-                <h2>The Challenge</h2>
+            </section>
+            <section className={`${styles.caseContainer} ${styles.longFormCaseStudy}`} aria-labelledby="challenge">
+                <h2 id="challenge">The Challenge</h2>
                 <p>The company initially had three Product Designers working independently across different products.</p>
                 <p>There was no shared design process, central source of truth, structured design backlog, consolidated UI library, or clear definition of Design responsibilities.</p>
                 <p>The existing workflow usually followed this sequence:</p>
@@ -64,8 +81,9 @@ export default function Resume() {
                 </ul>
                 <p>The products also presented user-facing problems, including complex payment journeys, fragmented login experiences, inconsistent data fields, different interaction patterns across platforms, and accessibility barriers affecting internal and external users.</p>
                 <p>These barriers were especially important in operational and Customer Support systems, where several employees with disabilities used the products daily.</p>
-
-                <h2>Understanding the Service</h2>
+            </section>
+            <section className={`${styles.caseContainer} ${styles.longFormCaseStudy}`} aria-labelledby="understanding-service">
+                <h2 id="understanding-service">Understanding the Service</h2>
                 <p>I treated the design process itself as a service.</p>
                 <p>The people using or participating in this service included:</p>
                 <ul>
@@ -86,14 +104,15 @@ export default function Resume() {
                 <p>To understand the current state, I interviewed designers and Product stakeholders, spoke with Engineering and Support teams, reviewed customer-support tickets, examined analytics and data consistency, observed existing workflows, and gathered feedback from users in different roles.</p>
                 <p>Customer Support was especially valuable because it provided direct evidence of recurring user problems. Its employees also helped identify accessibility barriers and operational issues that were not always visible to the product teams.</p>
                 <p>This research helped us understand both the user-facing experience and the internal teams, processes, systems, and decisions behind each interaction.</p>
-
-                <h2>The Service Design Approach</h2>
+            </section>
+            <section className={`${styles.caseContainer} ${styles.longFormCaseStudy}`} aria-labelledby="service-design-approach">
+                <h2 id="service-design-approach">The Service Design Approach</h2>
                 <p>I mapped how product work entered the organization, how decisions were made, when Design became involved, how information moved between teams, and where context was lost.</p>
                 <p>The new approach moved Design closer to the beginning of the service.</p>
                 <p>Instead of receiving a request for a completed solution, designers became involved when a demand first entered Product. They could help define the problem, identify affected users, select the appropriate research methods, shape the solution, review the implementation, and measure the results after release.</p>
                 <p>We created a flexible process based on the size, urgency, risk, and expected impact of each initiative. Not every project required the same amount of research or documentation.</p>
                 <p>Depending on the work, the process could include:</p>
-                <ol>
+                <ul>
                     <li>Problem framing and initial discovery</li>
                     <li>Stakeholder mapping</li>
                     <li>User and stakeholder research</li>
@@ -106,12 +125,13 @@ export default function Resume() {
                     <li>Accessibility review</li>
                     <li>Delivery planning</li>
                     <li>Measurement plans, analytics, and behaviour tracking</li>
-                </ol>
+                </ul>
                 <p>We documented this approach in a <strong>Product Design Playbook</strong>.</p>
                 <p>The playbook explained how the team worked, when each method should be used, which stakeholders should participate, and how the process should adapt to different types of work.</p>
                 <p>It also became an onboarding resource, helping new designers understand the team structure, responsibilities, standards, tools, and delivery expectations.</p>
-
-                <h2>The New Design Operating Model</h2>
+            </section>
+            <section className={`${styles.caseContainer} ${styles.longFormCaseStudy}`} aria-labelledby="design-operating-model">
+                <h2 id="design-operating-model">The New Design Operating Model</h2>
                 <p>For each significant initiative, we defined accountable representatives from:</p>
                 <ul>
                     <li>Product</li>
@@ -126,8 +146,9 @@ export default function Resume() {
                 <p>External stakeholders could also participate throughout the process. In some projects, clients joined the initial conversations, reviewed early prototypes, participated in testing, and received access to completed features before publication so they could validate the experience.</p>
                 <p>Each epic was reviewed by the relevant functions. Its stories and tasks could include design, engineering, research, accessibility, content, compliance, testing, and final validation.</p>
                 <p>This created better alignment and traceability from the original problem through implementation and release.</p>
-
-                <h2>Connected Workflows and Documentation</h2>
+            </section>
+            <section className={`${styles.caseContainer} ${styles.longFormCaseStudy}`} aria-labelledby="connected-workflows">
+                <h2 id="connected-workflows">Connected Workflows and Documentation</h2>
                 <p>We introduced a dedicated Design Kanban in Azure DevOps and connected it with the existing Product, Business, and Engineering workflows.</p>
                 <p>The structure included:</p>
                 <ul>
@@ -143,15 +164,17 @@ export default function Resume() {
                 <p>The goal was not documentation for its own sake. We tested and adjusted the process as teams began using it.</p>
                 <p>For example, we initially tried to document too much design detail inside Azure DevOps. This created additional work without enough value, so detailed visual documentation remained in Figma while Azure DevOps contained the information required for planning, ownership, delivery, and traceability.</p>
                 <p>The operating model was treated like a product: it was tested, reviewed, and continuously improved.</p>
-
-                <h2>Accessibility and Inclusion</h2>
+            </section>
+            <section className={`${styles.caseContainer} ${styles.longFormCaseStudy}`} aria-labelledby="accessibility-inclusion">
+                <h2 id="accessibility-inclusion">Accessibility and Inclusion</h2>
                 <p>Accessibility became part of the process rather than a final review.</p>
                 <p>Design requirements included accessibility expectations, and designers could explain why keyboard support, semantic structure, screen-reader compatibility, focus management, contrast, and other requirements were necessary.</p>
                 <p>Some developers initially questioned the value of these requirements. I addressed this through workshops, practical examples, closer collaboration, and clearer documentation.</p>
                 <p>Employees with disabilities, especially those working in Customer Support, were included in conversations about internal tools and operational workflows.</p>
                 <p>I also treated clear and consistent documentation as a form of organizational accessibility. Standard language and predictable task structures made information easier for everyone to understand and reduced dependence on individual writing styles.</p>
-
-                <h2>Building Capability and Changing Culture</h2>
+            </section>
+            <section className={`${styles.caseContainer} ${styles.longFormCaseStudy}`} aria-labelledby="capability-culture">
+                <h2 id="capability-culture">Building Capability and Changing Culture</h2>
                 <p>The transformation required more than creating a workflow. It required changing how the organization understood Design.</p>
                 <p>I presented the proposed structure, resource needs, priorities, Design System direction, and short-, medium-, and long-term goals to senior leaders and C-level stakeholders.</p>
                 <p>The short-term focus was solving immediate communication and delivery problems.</p>
@@ -180,8 +203,9 @@ export default function Resume() {
                 <p>The UX Writers were introduced later to revisit existing features, improve terminology and content, and support medium-term product improvements.</p>
                 <p>I supported hiring, onboarding, mentoring, workload planning, identification of individual strengths, and the development of potential design leads.</p>
                 <p>Regular workshops created a space for designers to exchange knowledge. These sessions were also opened to developers and other stakeholders, helping Product Design practices spread beyond the Design team.</p>
-
-                <h2>Creating the Design System Foundation</h2>
+            </section>
+            <section className={`${styles.caseContainer} ${styles.longFormCaseStudy}`} aria-labelledby="design-system-foundation">
+                <h2 id="design-system-foundation">Creating the Design System Foundation</h2>
                 <p>As the process became more structured, Engineering began to see clearer evidence behind design decisions and more opportunities to reuse components.</p>
                 <p>This created the foundation for a shared UI kit and later a formal Design System.</p>
                 <p>The team began consolidating:</p>
@@ -199,68 +223,84 @@ export default function Resume() {
                 <p>Before this, designers could define component behaviour in Figma but would often see the real interaction only after development was completed.</p>
                 <p>Storybook allowed designers and engineers to review components earlier, test states and behaviours, discuss implementation details, and identify differences before the components were used across products.</p>
                 <p>This reduced uncertainty and created a stronger connection between the Figma libraries and the implemented components.</p>
-
-                <h2>Challenges</h2>
+            </section>
+            <section className={`${styles.caseContainer} ${styles.longFormCaseStudy}`} aria-labelledby="challenges">
+                <h2 id="challenges">Challenges</h2>
                 <p>The main challenge was not creating the process. It was maintaining adoption.</p>
                 <p>Product Managers and Product Owners had to change a familiar workflow and involve Design earlier. Designers also had to accept greater responsibility for presenting evidence, explaining decisions, and participating throughout delivery.</p>
                 <p>Engineering teams used different technologies and had different levels of support for accessibility, component reuse, and modern front-end standards.</p>
                 <p>The transformation required continuous facilitation, conflict resolution, clarification of responsibilities, workshops, and adjustments based on feedback.</p>
                 <p>Instead of treating the first workflow as final, we monitored its use and removed steps that created effort without enough value.</p>
-
-                <h2>Outcomes</h2>
+            </section>
+            <section className={`${styles.caseContainer} ${styles.longFormCaseStudy}`} aria-labelledby="outcomes">
+                <h2 id="outcomes">Outcomes</h2>
                 <p>The transformation changed both how products were designed and how teams worked together.</p>
 
-                <h3>Organizational Impact</h3>
-                <ul>
-                    <li>Design became involved from problem definition through delivery and measurement.</li>
-                    <li>Designers gained greater ownership and could present the evidence behind their decisions.</li>
-                    <li>Product, Design, Engineering, Business, Compliance, clients, and other stakeholders had clearer responsibilities.</li>
-                    <li>The Design team grew from three Product Designers to 10 Product Designers and two UX Writers.</li>
-                    <li>Workshops, mentoring, and the Product Design Playbook created a more consistent design culture.</li>
-                    <li>Designers gained better visibility into the purpose and expected impact of their work.</li>
-                    <li>The company developed a clearer long-term vision for Design, accessibility, automation, and scalable product delivery.</li>
-                </ul>
+                <section aria-labelledby="organizational-impact">
+                    <h3 id="organizational-impact">Organizational Impact</h3>
+                    <ul>
+                        <li>Design became involved from problem definition through delivery and measurement.</li>
+                        <li>Designers gained greater ownership and could present the evidence behind their decisions.</li>
+                        <li>Product, Design, Engineering, Business, Compliance, clients, and other stakeholders had clearer responsibilities.</li>
+                        <li>The Design team grew from three Product Designers to 10 Product Designers and two UX Writers.</li>
+                        <li>Workshops, mentoring, and the Product Design Playbook created a more consistent design culture.</li>
+                        <li>Designers gained better visibility into the purpose and expected impact of their work.</li>
+                        <li>The company developed a clearer long-term vision for Design, accessibility, automation, and scalable product delivery.</li>
+                    </ul>
+                </section>
 
-                <h3>Delivery and Operational Impact</h3>
-                <ul>
-                    <li>Connected Kanban workflows improved traceability across Product, Design, Business, and Engineering.</li>
-                    <li>Structured requests and requirements reduced missing context and communication problems.</li>
-                    <li>Research, journey mapping, prototyping, accessibility reviews, and usability testing became part of regular product work.</li>
-                    <li>Designers could review implementation and follow product performance after release.</li>
-                    <li>Design and development time was reduced by approximately 30%.</li>
-                    <li>Better documentation and standardized task structures created a foundation for automation and future AI-assisted workflows.</li>
-                    <li>Existing Azure DevOps capabilities were used more effectively to manage responsibilities, task movement, and delivery history.</li>
-                </ul>
+                <section aria-labelledby="delivery-operational-impact">
+                    <h3 id="delivery-operational-impact">Delivery and Operational Impact</h3>
+                    <ul>
+                        <li>Connected Kanban workflows improved traceability across Product, Design, Business, and Engineering.</li>
+                        <li>Structured requests and requirements reduced missing context and communication problems.</li>
+                        <li>Research, journey mapping, prototyping, accessibility reviews, and usability testing became part of regular product work.</li>
+                        <li>Designers could review implementation and follow product performance after release.</li>
+                        <li>Design and development time was reduced by approximately 30%.</li>
+                        <li>Better documentation and standardized task structures created a foundation for automation and future AI-assisted workflows.</li>
+                        <li>Existing Azure DevOps capabilities were used more effectively to manage responsibilities, task movement, and delivery history.</li>
+                    </ul>
+                </section>
 
-                <h3>Product Quality and User Experience</h3>
-                <ul>
-                    <li>Visual and interaction consistency improved across products.</li>
-                    <li>Accessibility became a defined requirement rather than a final review.</li>
-                    <li>Support issues related to previously identified product problems decreased.</li>
-                    <li>Analytics, Hotjar, user feedback, and feature tracking became part of the product process.</li>
-                    <li>Research and testing helped teams balance business needs with real user needs.</li>
-                    <li>Better validation reduced differences between prototypes and final implementations.</li>
-                    <li>The organization gained stronger evidence for future product decisions and improvements.</li>
-                </ul>
+                <section aria-labelledby="product-quality-user-experience">
+                    <h3 id="product-quality-user-experience">Product Quality and User Experience</h3>
+                    <ul>
+                        <li>Visual and interaction consistency improved across products.</li>
+                        <li>Accessibility became a defined requirement rather than a final review.</li>
+                        <li>Support issues related to previously identified product problems decreased.</li>
+                        <li>Analytics, Hotjar, user feedback, and feature tracking became part of the product process.</li>
+                        <li>Research and testing helped teams balance business needs with real user needs.</li>
+                        <li>Better validation reduced differences between prototypes and final implementations.</li>
+                        <li>The organization gained stronger evidence for future product decisions and improvements.</li>
+                    </ul>
+                </section>
 
-                <h3>Design System and Broader Influence</h3>
-                <ul>
-                    <li>A shared and documented UI kit was consolidated.</li>
-                    <li>The formal Design System initiative began.</li>
-                    <li>Storybook improved component validation and collaboration between Design and Engineering.</li>
-                    <li>Designers could review implemented component states and behaviours earlier.</li>
-                    <li>Component reuse and clearer standards reduced unnecessary duplication.</li>
-                    <li>Related teams in the United States and France began consulting the team about its process, testing approach, and Design System.</li>
-                    <li>Some international teams began considering the methods and system foundations for their own products.</li>
-                </ul>
-
-                <h2>What I Learned</h2>
+                <section aria-labelledby="design-system-influence">
+                    <h3 id="design-system-influence">Design System and Broader Influence</h3>
+                    <ul>
+                        <li>A shared and documented UI kit was consolidated.</li>
+                        <li>The formal Design System initiative began.</li>
+                        <li>Storybook improved component validation and collaboration between Design and Engineering.</li>
+                        <li>Designers could review implemented component states and behaviours earlier.</li>
+                        <li>Component reuse and clearer standards reduced unnecessary duplication.</li>
+                        <li>Related teams in the United States and France began consulting the team about its process, testing approach, and Design System.</li>
+                        <li>Some international teams began considering the methods and system foundations for their own products.</li>
+                    </ul>
+                </section>
+            </section>
+            <section className={`${styles.caseContainer} ${styles.longFormCaseStudy}`} aria-labelledby="learnings">
+                <h2 id="learnings">What I Learned</h2>
                 <p>The most important lesson was that a design process cannot simply be imposed.</p>
                 <p>It must fit the organization, the size and risk of the work, the delivery environment, and the people expected to use it.</p>
                 <p>A successful design function needs enough structure to create clarity, traceability, accessibility, and quality, but it must remain flexible enough to support fast delivery.</p>
                 <p>This transformation worked because the process itself was treated as a service that could be researched, mapped, prototyped, tested, measured, and continuously improved.</p>
             </section>
-            <Button href="/portfolio" icon="long-arrow-alt-left" label="Back to Portfolio"/>
+            <footer className={styles.caseFooter}>
+                <nav aria-label="Case study navigation">
+                    <Button href="/portfolio" icon="long-arrow-alt-left" label="Back to Portfolio"/>
+                    <Button href="/portfolio/ux-ui-medical-platform" label="Next case study"/>
+                </nav>
+            </footer>
         </article>
     )
 }

--- a/src/app/portfolio/personal-website/page.tsx
+++ b/src/app/portfolio/personal-website/page.tsx
@@ -18,70 +18,101 @@ export const metadata: Metadata = {
 export default function Resume() {
     return (
         <article className={`${globals.wrapper} ${globals.sectionPadding} ${styles.resumeContainer}`}>
-            <div className={styles.titleContainer}>
-                <span className={styles.breadcrumbs}><a href="/portfolio" title="Back to Portfolio" rel="nofollow noindex">Portfolio</a></span>
+            <header className={styles.titleContainer}>
+                <p className={styles.eyebrow}>Personal Website</p>
                 <h1>Personal website</h1>
-            </div>
-            <section id="personal-website" className={styles.caseContainer}>
+                <p>Personal website and portfolio</p>
+                <dl className={styles.caseDetails}>
+                    <div>
+                        <dt>Focus</dt>
+                        <dd>DevOps, DesignOps, and interaction design</dd>
+                    </div>
+                    <div>
+                        <dt>Platform</dt>
+                        <dd>GitHub</dd>
+                    </div>
+                </dl>
+            </header>
+            <section className={styles.caseContainer} aria-labelledby="personal-website-overview">
+                <h2 id="personal-website-overview">Overview</h2>
+                <p>
+                    After deciding to move to Canada, I realized it was the perfect time to finally develop my own personal website and portfolio. With this life change came the opportunity to fully dedicate myself to building a platform that represents my professional and creative journey.
+                </p>
+                <p>
+                    I wanted to show all my skills, including DevOps, DesignOps, and interaction design, to create a seamless and visually captivating experience. Additionally, I'm committed to continuous improvement, ensuring that my website evolves with the latest trends and technologies. My website is not just a space to showcase my work, but also a way to share my passion for technology and connect with a new community.
+                </p>
+                <p>
+                    I'm excited to share my journey and demonstrate how my comprehensive skill set can contribute to future projects in this new chapter of my life in Canada.
+                </p>
+            </section>
+            <section className={`${styles.caseContainer} ${styles.titleSection}`} aria-labelledby="planning-documentation">
                 <div>
+                    <h2 id="planning-documentation">I planned and documented all the process</h2>
                     <p>
-                        After deciding to move to Canada, I realized it was the perfect time to finally develop my own personal website and portfolio. With this life change came the opportunity to fully dedicate myself to building a platform that represents my professional and creative journey.
-                    </p>
-                    <p>
-                        I wanted to show all my skills, including DevOps, DesignOps, and interaction design, to create a seamless and visually captivating experience. Additionally, I'm committed to continuous improvement, ensuring that my website evolves with the latest trends and technologies. My website is not just a space to showcase my work, but also a way to share my passion for technology and connect with a new community.
-                    </p>
-                    <p>
-                        I'm excited to share my journey and demonstrate how my comprehensive skill set can contribute to future projects in this new chapter of my life in Canada.
+                    I decided to use GitHub for my project board and repository. It’s free and an awesome tool.
                     </p>
                 </div>
-                <div className={styles.titleSection}>
-                    <div>
-                        <h3>I planned and documented all the process</h3>
-                        <p>
-                        I decided to use GitHub for my project board and repository. It’s free and an awesome tool.
-                        </p>
-                    </div>
+                <div className={styles.sectionAction}>
                     <Button type="link" href="https://github.com/users/maikelsalles/projects/1" icon="external-link-alt" target="blank" label="GitHub Project"/>
                 </div>
-                <picture>
-                    <source srcSet={img1.src} />
-                    <Image src={img1} alt="A print screen from GitHub project kanban board within lots of tasks." />
-                </picture>
-                <div className={styles.titleSection}>
-                    <div>
-                        <h3>Design System, just for fun...</h3>
-                        <p>Are there something more satisfying than starting a design system from scratch, even when the project is to small to justify to do it? #MyProjectMyRules</p>
-                    </div>
+                <figure>
+                    <picture>
+                        <source srcSet={img1.src} />
+                        <Image src={img1} alt="A print screen from GitHub project kanban board within lots of tasks." />
+                    </picture>
+                </figure>
+            </section>
+            <section className={`${styles.caseContainer} ${styles.titleSection}`} aria-labelledby="personal-design-system">
+                <div>
+                    <h2 id="personal-design-system">Design System, just for fun...</h2>
+                    <p>Are there something more satisfying than starting a design system from scratch, even when the project is to small to justify to do it? #MyProjectMyRules</p>
+                </div>
+                <div className={styles.sectionAction}>
                     <Button type="link" href="https://www.figma.com/file/sO4RwR8UsUSSsYPdBZY8XD/Portfolio-Maikel-Salles-team-library?type=design&node-id=0-1&mode=design" icon="external-link-alt" target="blank" label="Figma Design System"/>
                 </div>
-                <picture>
-                    <source srcSet={img2.src} />
-                    <Image src={img2} alt="An image from Figma showing a design system with components." />
-                </picture>
-                <div className={styles.titleSection}>
-                    <div>
-                        <h3>Prototypes</h3>
-                        <p>I wanted an elegantly simple yet rich in detail, meticulously crafted pixel by pixel through the use of components.</p>
-                    </div>
+                <figure>
+                    <picture>
+                        <source srcSet={img2.src} />
+                        <Image src={img2} alt="An image from Figma showing a design system with components." />
+                    </picture>
+                </figure>
+            </section>
+            <section className={`${styles.caseContainer} ${styles.titleSection}`} aria-labelledby="personal-website-prototypes">
+                <div>
+                    <h2 id="personal-website-prototypes">Prototypes</h2>
+                    <p>I wanted an elegantly simple yet rich in detail, meticulously crafted pixel by pixel through the use of components.</p>
+                </div>
+                <div className={styles.sectionAction}>
                     <Button type="link" href="https://www.figma.com/file/sO4RwR8UsUSSsYPdBZY8XD/Portfolio-Maikel-Salles-team-library?type=design&node-id=511-944&mode=design" icon="external-link-alt" target="blank" label="Figma Prototypes"/>
                 </div>
-                <picture>
-                    <source srcSet={img3.src} />
-                    <Image src={img3} alt="Image from Figma showing prototype with screens." />
-                </picture>
-                <div className={styles.titleSection}>
-                    <div>
-                        <h3>GitHub repository</h3>
-                        <p>I chose GitHub for its robust project management tools, such as issues, milestones, and project boards, which enable efficient task organization, progress tracking, and team collaboration.</p>
-                    </div>
+                <figure>
+                    <picture>
+                        <source srcSet={img3.src} />
+                        <Image src={img3} alt="Image from Figma showing prototype with screens." />
+                    </picture>
+                </figure>
+            </section>
+            <section className={`${styles.caseContainer} ${styles.titleSection}`} aria-labelledby="github-repository">
+                <div>
+                    <h2 id="github-repository">GitHub repository</h2>
+                    <p>I chose GitHub for its robust project management tools, such as issues, milestones, and project boards, which enable efficient task organization, progress tracking, and team collaboration.</p>
+                </div>
+                <div className={styles.sectionAction}>
                     <Button type="link" href="https://github.com/maikelsalles/personalwebsite" icon="external-link-alt" target="blank" label="GitHub Repository"/>
                 </div>
-                <picture>
-                    <source srcSet={img4.src} />
-                    <Image src={img4} alt="The repository on GitHub shows the files from the project." />
-                </picture>
+                <figure>
+                    <picture>
+                        <source srcSet={img4.src} />
+                        <Image src={img4} alt="The repository on GitHub shows the files from the project." />
+                    </picture>
+                </figure>
             </section>
-            <Button href="/portfolio" icon="long-arrow-alt-left" label="Back to Portfolio"/>
+            <footer className={styles.caseFooter}>
+                <nav aria-label="Case study navigation">
+                    <Button href="/portfolio" icon="long-arrow-alt-left" label="Back to Portfolio"/>
+                    <Button href="/portfolio/design-system-engineer" label="Next case study"/>
+                </nav>
+            </footer>
         </article>
     )
 }

--- a/src/app/portfolio/portfolio.module.scss
+++ b/src/app/portfolio/portfolio.module.scss
@@ -55,10 +55,30 @@
 
 .resumeContainer {
   padding-top: var(--header-height-sm);
-  .breadcrumbs {
+  .titleContainer {
+    margin-bottom: 2rem;
+    border-bottom: 1px solid var(--foreground-alpha-10);
+    padding: 3rem 0;
+  }
+  .eyebrow {
     color: var(--primary-regular);
-    &:after {
-      content: " /"
+    font-weight: bold;
+    padding-bottom: .5rem;
+  }
+  .caseDetails {
+    display: grid;
+    gap: 1rem;
+    margin: 1rem 0 0;
+    max-width: 1200px;
+    div {
+      display: grid;
+      gap: .25rem;
+    }
+    dt {
+      font-weight: bold;
+    }
+    dd {
+      margin: 0;
     }
   }
   h1 {
@@ -70,6 +90,9 @@
   }
   .caseContainer {
     text-align: left;
+    & + .caseContainer {
+      margin-top: 2rem;
+    }
     h2 {
       margin-bottom: 1rem;
     }
@@ -78,9 +101,11 @@
       height: auto;
     }
     picture {
-      margin-bottom: 2rem;
       width: 100%;
       display: flex;
+    }
+    figure {
+      margin: 0 0 2rem;
     }
     h3 {
       margin-bottom: 1rem;
@@ -103,7 +128,7 @@
   }
   .longFormCaseStudy {
     h2 {
-      margin: 3rem 0 1rem;
+      margin: 3rem 0 0;
       &:first-child {
         margin-top: 0;
       }
@@ -116,11 +141,16 @@
       margin: 0 0 2rem;
       padding-left: 1.5rem;
     }
-    li{
-      list-style: disc;
+    li {
       &:not(:first-child) {
         margin-top: .5rem;
       }
+    }
+    ul li {
+      list-style: disc;
+    }
+    ol li {
+      list-style: decimal;
     }
   }
   .titleSection {
@@ -129,9 +159,29 @@
     flex-direction: column;
     padding: 0 0 2rem 0;
   }
+  .sectionAction {
+    margin-bottom: 2rem;
+  }
+  .caseFooter {
+    margin-top: 2rem;
+    nav {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      gap: 1rem;
+    }
+  }
 }
 @include for-tablet-landscape-up {
   .resumeContainer {
     padding-top: var(--header-height-lg);
+    .caseDetails {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+    .caseFooter nav {
+      flex-direction: row;
+      justify-content: space-between;
+      align-items: center;
+    }
   }
 }

--- a/src/app/portfolio/ux-ui-medical-platform/page.tsx
+++ b/src/app/portfolio/ux-ui-medical-platform/page.tsx
@@ -19,51 +19,76 @@ export const metadata: Metadata = {
 export default function Resume() {
     return (
         <article className={`${globals.wrapper} ${globals.sectionPadding} ${styles.resumeContainer}`}>
-            <div className={styles.titleContainer}>
-                <span className={styles.breadcrumbs}><a href="/portfolio" title="Back to Portfolio" rel="nofollow noindex">Portfolio</a></span>
+            <header className={styles.titleContainer}>
+                <p className={styles.eyebrow}>UX/UI Medical Platform</p>
                 <h1>Medical Platform</h1>
-            </div>
-            <section id="personal-website" className={styles.caseContainer}>
-                <div>
-                    <p>
-                        As the Volunteer Lead Product Designer for an innovative medical platform at a Canadian startup, I spearheaded the design process, ensuring seamless user experiences and intuitive interfaces. Collaborating closely with cross-functional teams, I translated user needs and business requirements into compelling design solutions.
-                    </p>
-                    <p>
-                        My role involved overseeing the end-to-end design workflow, from concept ideation to prototyping and user testing, all while upholding high standards of usability and accessibility, and leveraging my expertise in product design and deep research of the healthcare landscape.
-                    </p>
-                </div>                
-                <div>
-                    <h3>Design thinking!</h3>
-                    <p>
-                        I utilized design thinking to innovate, by empathizing with users, brainstorming creative solutions, and iterating rapidly based on feedback, I drove the development of user-centric features. This approach ensured that the platform effectively addressed healthcare professionals' and patients' needs,
-                    </p>
-                </div>
+                <p>Medical Management Platform</p>
+                <dl className={styles.caseDetails}>
+                    <div>
+                        <dt>Role</dt>
+                        <dd>Product Designer — Selected Freelance Project</dd>
+                    </div>
+                    <div>
+                        <dt>Company</dt>
+                        <dd>Sanmyaku Entertainment</dd>
+                    </div>
+                    <div>
+                        <dt>Dates</dt>
+                        <dd>November 2023–January 2024</dd>
+                    </div>
+                </dl>
+            </header>
+            <section className={styles.caseContainer} aria-labelledby="medical-platform-overview">
+                <h2 id="medical-platform-overview">Overview</h2>
+                <p>
+                    As the Volunteer Lead Product Designer for an innovative medical platform at a Canadian startup, I spearheaded the design process, ensuring seamless user experiences and intuitive interfaces. Collaborating closely with cross-functional teams, I translated user needs and business requirements into compelling design solutions.
+                </p>
+                <p>
+                    My role involved overseeing the end-to-end design workflow, from concept ideation to prototyping and user testing, all while upholding high standards of usability and accessibility, and leveraging my expertise in product design and deep research of the healthcare landscape.
+                </p>
+            </section>
+            <section className={styles.caseContainer} aria-labelledby="design-thinking">
+                <h2 id="design-thinking">Design thinking!</h2>
+                <p>
+                    I utilized design thinking to innovate, by empathizing with users, brainstorming creative solutions, and iterating rapidly based on feedback, I drove the development of user-centric features. This approach ensured that the platform effectively addressed healthcare professionals' and patients' needs,
+                </p>
                 <div className={styles.advise}>
                     <span className={`${icons.info} ${icons.icon}`}></span>
                     The details of this project are confidential, however, I can provide a brief overview.
                 </div>
-                <picture>
-                    <source srcSet={img1.src} />
-                    <Image src={img1} alt="A screen from Figma Jam with organograms and fluxes." />
-                </picture>
-                <div>
-                    <h3>Atomic Design System</h3>
-                    <p>After recognizing the scale and complexity of this medical platform, which encompasses numerous features and releases, I developed a robust design system to ensure consistency and scalability across the entire project.</p>
-                </div>
-                <picture>
-                    <source srcSet={img2.src} />
-                    <Image src={img2} alt="A print screen from Figma showing a design system." />
-                </picture>
-                <div>
-                    <h3>Prototypes</h3>
-                    <p>I utilized the latest and most advanced features of Figma to ensure that the design process was as streamlined and efficient as possible, aiming for an elegantly simple yet detail-rich outcome, meticulously crafted pixel by pixel using components.</p>
-                </div>
-                <picture>
-                    <source srcSet={img3.src} />
-                    <Image src={img3} alt="A print screen from Figma with prototypes.```" />
-                </picture>
+                <figure>
+                    <picture>
+                        <source srcSet={img1.src} />
+                        <Image src={img1} alt="A screen from Figma Jam with organograms and fluxes." />
+                    </picture>
+                </figure>
             </section>
-            <Button href="/portfolio" icon="long-arrow-alt-left" label="Back to Portfolio"/>
+            <section className={styles.caseContainer} aria-labelledby="atomic-design-system">
+                <h2 id="atomic-design-system">Atomic Design System</h2>
+                <p>After recognizing the scale and complexity of this medical platform, which encompasses numerous features and releases, I developed a robust design system to ensure consistency and scalability across the entire project.</p>
+                <figure>
+                    <picture>
+                        <source srcSet={img2.src} />
+                        <Image src={img2} alt="A print screen from Figma showing a design system." />
+                    </picture>
+                </figure>
+            </section>
+            <section className={styles.caseContainer} aria-labelledby="medical-platform-prototypes">
+                <h2 id="medical-platform-prototypes">Prototypes</h2>
+                <p>I utilized the latest and most advanced features of Figma to ensure that the design process was as streamlined and efficient as possible, aiming for an elegantly simple yet detail-rich outcome, meticulously crafted pixel by pixel using components.</p>
+                <figure>
+                    <picture>
+                        <source srcSet={img3.src} />
+                        <Image src={img3} alt="A print screen from Figma with prototypes.```" />
+                    </picture>
+                </figure>
+            </section>
+            <footer className={styles.caseFooter}>
+                <nav aria-label="Case study navigation">
+                    <Button href="/portfolio" icon="long-arrow-alt-left" label="Back to Portfolio"/>
+                    <Button href="/portfolio/personal-website" label="Next case study"/>
+                </nav>
+            </footer>
         </article>
     )
 }

--- a/src/app/resume/resume.module.scss
+++ b/src/app/resume/resume.module.scss
@@ -7,6 +7,9 @@
     a {
         margin-right: 0;
     }
+    header {
+        padding: 2rem 0 1rem;
+    }
 }
 .sideSlider {
     background-color: var(--background-rgb);


### PR DESCRIPTION
Closes #73

Parent: #67 — Improve Portfolio Presentation

## Summary
- Apply semantic article, header, definition-list, labelled-section, figure, footer, and navigation structures to the four linked portfolio case studies.
- Preserve the Head of Product Design content while adding accessible heading relationships and real next-case navigation.
- Add responsive portfolio presentation styles and retain the approved global heading presentation changes.

## Files changed
- `src/app/_mixins.scss`
- `src/app/globals.scss`
- `src/app/portfolio/design-system-engineer/page.tsx`
- `src/app/portfolio/head-of-product-design/page.tsx`
- `src/app/portfolio/personal-website/page.tsx`
- `src/app/portfolio/portfolio.module.scss`
- `src/app/portfolio/ux-ui-medical-platform/page.tsx`
- `src/app/resume/resume.module.scss`

## Validation
- [x] `npm run lint`
- [x] `npm run build`
- [x] Semantic heading, ID, ARIA relationship, list, figure, and navigation review
- [x] Head of Product Design content preservation review
- [x] Scope review: orphan `/portfolio/product-designer` route excluded

## Scope
- No portfolio content rewriting, metadata/SEO work, orphan-route restructuring, or unrelated feature work.
- Existing non-blocking SWC lockfile and Browserslist warnings remain unchanged.